### PR TITLE
adding support for custom access_type

### DIFF
--- a/lib/omnicontacts/authorization/oauth2.rb
+++ b/lib/omnicontacts/authorization/oauth2.rb
@@ -30,7 +30,7 @@ module OmniContacts
             :client_id => client_id,
             :scope => encode(scope),
             :response_type => "code",
-            :access_type => "online",
+            :access_type => access_type,
             :approval_prompt => "auto",
             :redirect_uri => encode(redirect_uri)
           })

--- a/lib/omnicontacts/middleware/oauth2.rb
+++ b/lib/omnicontacts/middleware/oauth2.rb
@@ -13,7 +13,7 @@ module OmniContacts
     class OAuth2 < BaseOAuth
       include Authorization::OAuth2
 
-      attr_reader :client_id, :client_secret, :redirect_path
+      attr_reader :client_id, :client_secret, :redirect_path, :access_type
 
       def initialize app, client_id, client_secret, options ={}
         super app, options
@@ -21,6 +21,7 @@ module OmniContacts
         @client_secret = client_secret
         @redirect_path = options[:redirect_path] || "#{ MOUNT_PATH }#{class_name}/callback"
         @ssl_ca_file = options[:ssl_ca_file]
+        @access_type = options[:access_type] || "online"
       end
 
       def request_authorization_from_user


### PR DESCRIPTION
In order to get a refresh token from gmail. `access_type` must be set to 'offline'